### PR TITLE
Typo. Replacing nonexistent ":=/" with "/=:".

### DIFF
--- a/HSoM/Music.lhs
+++ b/HSoM/Music.lhs
@@ -285,7 +285,7 @@ Modify  :: Control -> Music a  -> Music a
 \end{spec}
 These four constructors then are also polymorphic functions.
 
-%%     |  Music a :=/ Music a              -- parallel composition
+%%     |  Music a /=: Music a              -- parallel composition
 %%     (short)
 
 %%   The first line here looks odd: the name |Primitive| appears
@@ -343,7 +343,7 @@ concert A.
   chapter.  You can see now that they are actually constructors of an
   algebraic data type.)
 
-%% \item |m1 :=/ m2| is also a parallel composition of |m1| and |m2|, but
+%% \item |m1 /=: m2| is also a parallel composition of |m1| and |m2|, but
 %%   its duration is that of the shorter of |m1| and |m2|.
 
 \item |Modify cntrl m| is an ``annotated'' version of |m| in which the

--- a/HSoM/Performance.lhs
+++ b/HSoM/Performance.lhs
@@ -378,7 +378,7 @@ perf pm
 \label{fig:real-perform}
 \end{figure}
 
-%%      m1 :=/ m2                  -> 
+%%      m1 /=: m2                  ->
 %%              let  (pf1,d1) = perf pm c m1
 %%                   (pf2,d2) = perf pm c m2
 %%              in (merge pf1 pf2, max d1 d2)


### PR DESCRIPTION
There are ":=/" instead of "/=:" in a couple of places.