### PR TITLE
type Pitch should be Music Pitch

### DIFF
--- a/HSoM/Music.lhs
+++ b/HSoM/Music.lhs
@@ -727,7 +727,7 @@ simple such as |play (note qn (C,4))|, Haskell cannot infer exactly
 what kind of number 4 is, and therefore cannot infer that |(C,4)| is
 intended to be a |Pitch|.  We can get around this either by writing:
 \begin{spec}
-m :: Pitch
+m :: Music Pitch
 m = note qn (C,4)
 \end{spec}
 in which case |play m| will work just fine, or we can include the type

--- a/ReadMe.txt
+++ b/ReadMe.txt
@@ -78,7 +78,7 @@ timidity -iA -Os &
 
 On gentoo:  run:
 aconnect -l
-This will output the Midi Through port number, say it is port number is 14,
+This will output the Midi Through port number, say, it is port number 14,
 then run:
 aconnect 14:0 128:0
 This will connect a timidity default port (128) to port 14

--- a/ReadMe.txt
+++ b/ReadMe.txt
@@ -76,6 +76,14 @@ Then, while Euterpea programs are running, you must have timidity running
 in the background:
 timidity -iA -Os &
 
+On gentoo:  run:
+aconnect -l
+This will output the Midi Through port number, say it is port number is 14,
+then run:
+aconnect 14:0 128:0
+This will connect a timidity default port (128) to port 14
+Now Euterpea should direct Midi stream to standard output.
+
 
 --------- Mac OS X ---------
 OS X is the least desirable platform on which to run Euterpea.  In fact,  


### PR DESCRIPTION
m :: Pitch
m = note qn(C,4)

Couldn't match type ‘Music (PitchClass, t0)’ …
                  with ‘(PitchClass, Octave)’
    Expected type: Pitch
      Actual type: Music (PitchClass, t0)
    In the expression: note qn (C, 4)
    In an equation for ‘m’: m = note qn (C, 4)
Compilation failed.
