### PR TITLE
Update information about using on Mac OS X

### DIFF
--- a/Euterpea/Examples/EnableGUI.hs
+++ b/Euterpea/Examples/EnableGUI.hs
@@ -1,4 +1,24 @@
 {-# LANGUAGE ForeignFunctionInterface #-}
+{--
+On Mac OS X, with versions of GHC prior to 7.8, you will have to use this
+``EnableGUI trick'' to run GUI programs for Euterpea from within ghci.
+
+To do so, first compile this file, EnableGUI.hs, to binary:
+    ghc -c -fffi EnableGUI.hs
+
+(Note: on some systems it is necessary to add the option
+``-framework ApplicationServices'')
+Then, run your Euterpea GUI programs in ghci like this:
+
+ghci UIExamples.hs EnableGUI
+*UIExamples> :m +EnableGUI
+*UIExamples EnableGUI> enableGUI >> main
+
+With this, GHCi will be able to fully activate the Graphics Window. (Fully
+compiled GUI programs do not suffer from this anomaly.)
+
+--}
+
 module EnableGUI(enableGUI) where
 
 import Data.Int

--- a/ReadMe.txt
+++ b/ReadMe.txt
@@ -78,31 +78,23 @@ timidity -iA -Os &
 
 
 --------- Mac OS X ---------
-OS X is the least desirable platform on which to run Euterpea.  In fact,  
-the latest release of OS X (Mavericks) has trouble with GHC in general.
+Euterpea is known to work fine on OS X (including Mavericks) when used with
+GHC 7.8.3 & Haskell Platform 2014.2.0.0 or later.
 
-We, the maintainers, currently do not have a Mac to test with, and so we 
-have no exact instructions for how to set up GHC and Euterpea to get them 
-into a functioning condition.
-
-Once Euterpea is set up, you may require additional steps to get MIDI sound 
-output working.  Download SimpleSynth and open it before you run ghci.  It’s 
+Once Euterpea is set up, you may require additional steps to get MIDI sound
+output working.  Download SimpleSynth and open it before you run ghci.  Itâ€™s
 a software MIDI synthesizer that plays MIDI output through the speaker.
 
-Furthermore, you will have to use the ``EnableGUI trick'' to run GUI 
-programs for Euterpea.  To do so, first compile EnableGUI.hs from the 
-Euterpea/Examples directory to binary:
-ghc -c -fffi EnableGUI.hs
-(Note: on some systems it is necessary to add the option 
-``-framework ApplicationServices'')
-Then, run your Euterpea GUI programs in ghci like this:
+With GHC 7.8.3 or later, to run the GUI examples in ghci reliably, you need
+to start gchi with -fno-ghci-sandbox, or set it within ghci as follows:
 
-ghci UIExamples.hs EnableGUI
-*UIExamples> :m +EnableGUI
-*UIExamples EnableGUI> enableGUI >> main
+    ghci -fno-ghci-sandbox
+    *: :set -fno-ghci-sandbox
+    *: :m + Euterpea.Examples.MUI
+    *: mui5
 
-With this, GHCi will be able to fully activate the Graphics Window. (Fully 
-compiled GUI programs do not suffer from this anomaly.)
+With older versions of GHC, you may need the ``EnableGUI trick''. See
+Euterpea/Examples/EnableGUI.hs for details.
 
 
 ------ Troubleshooting -----


### PR DESCRIPTION
Euterpea builds and runs fine, "out of the box" on a reasonably updated OS X system. Tested with GHC 7.8.3, Haskell Platform 2014.2.0.0, and Mac OS X 10.10 (Mavericks).

The notes for running the MUI examples under ghci are not relavant on a modern OS X. I put the new instructions in the ReadMe.txt, and moved the old ones to EnableGUI.hs for people with older systems.